### PR TITLE
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/library/src/main/java/com/yarolegovich/mp/io/MaterialPreferences.java
+++ b/library/src/main/java/com/yarolegovich/mp/io/MaterialPreferences.java
@@ -12,6 +12,14 @@ public class MaterialPreferences {
 
     private static final MaterialPreferences instance = new MaterialPreferences();
 
+    private UserInputModule.Factory userInputModuleFactory;
+    private StorageModule.Factory storageModuleFactory;
+
+    private MaterialPreferences() {
+        userInputModuleFactory = new StandardUserInputFactory();
+        storageModuleFactory = new SharedPrefsStorageFactory(null);
+    }
+
     public static MaterialPreferences instance() {
         return instance;
     }
@@ -22,14 +30,6 @@ public class MaterialPreferences {
 
     public static StorageModule getStorageModule(Context context) {
         return instance.storageModuleFactory.create(context);
-    }
-
-    private UserInputModule.Factory userInputModuleFactory;
-    private StorageModule.Factory storageModuleFactory;
-
-    private MaterialPreferences() {
-        userInputModuleFactory = new StandardUserInputFactory();
-        storageModuleFactory = new SharedPrefsStorageFactory(null);
     }
 
     public MaterialPreferences setUserInputModule(UserInputModule.Factory factory) {

--- a/sample/src/main/java/com/yarolegovich/materialprefsample/Prefs.java
+++ b/sample/src/main/java/com/yarolegovich/materialprefsample/Prefs.java
@@ -9,14 +9,6 @@ public class Prefs {
 
     private static Prefs instance;
 
-    public static void init(Context context) {
-        instance = new Prefs(context);
-    }
-
-    public static Prefs keys() {
-        return instance;
-    }
-
     public final String KEY_USE_LOVELY;
 
     public final String KEY_YEARS_OF_EXP;
@@ -46,4 +38,13 @@ public class Prefs {
         KEY_DATE_FORMAT = context.getString(R.string.pkey_date_format);
         KEY_TIME_FORMAT = context.getString(R.string.pkey_time_format);
     }
+
+    public static void init(Context context) {
+        instance = new Prefs(context);
+    }
+
+    public static Prefs keys() {
+        return instance;
+    }
+
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
This pull request removes 75 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava
