### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/library/src/main/java/com/yarolegovich/mp/util/Utils.java
+++ b/library/src/main/java/com/yarolegovich/mp/util/Utils.java
@@ -10,6 +10,8 @@ import android.util.TypedValue;
  */
 public class Utils {
 
+    private Utils() {}
+
     public static int dpToPixels(Context context, int dp) {
         Resources resources = context.getResources();
         DisplayMetrics metrics = resources.getDisplayMetrics();


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1118: Utility classes should not have public constructors
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava
