### PR TITLE
Changing MaterialPreferenceScreen to LinearLayout

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.3'
         classpath 'com.novoda:bintray-release:0.8.0'
     }
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'com.novoda.bintray-release'
 
 android {
     compileSdkVersion rootProject.compileSdkVersion
-    buildToolsVersion rootProject.buildToolsVersion
 
     defaultConfig {
         minSdkVersion 14

--- a/library/src/main/java/com/yarolegovich/mp/MaterialPreferenceScreen.java
+++ b/library/src/main/java/com/yarolegovich/mp/MaterialPreferenceScreen.java
@@ -6,9 +6,7 @@ import android.os.Build;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.ViewParent;
 import android.widget.LinearLayout;
-import android.widget.ScrollView;
 
 import com.yarolegovich.mp.io.UserInputModule;
 import com.yarolegovich.mp.io.StorageModule;
@@ -19,9 +17,7 @@ import java.util.List;
 /**
  * Created by yarolegovich on 01.05.2016.
  */
-public class MaterialPreferenceScreen extends ScrollView {
-
-    private LinearLayout container;
+public class MaterialPreferenceScreen extends LinearLayout {
 
     private UserInputModule userInputModule;
     private StorageModule storageModule;
@@ -44,19 +40,12 @@ public class MaterialPreferenceScreen extends ScrollView {
     }
 
     {
-        setFillViewport(true);
-        LinearLayout container = new LinearLayout(getContext());
-        container.setLayoutParams(new ViewGroup.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT));
-        container.setOrientation(LinearLayout.VERTICAL);
-        addView(container);
-        this.container = container;
+        setOrientation(LinearLayout.VERTICAL);
     }
 
     public void changeViewsVisibility(List<Integer> viewIds, boolean visible) {
         int visibility = visible ? VISIBLE : GONE;
-        changeViewsVisibility(container, viewIds, visibility);
+        changeViewsVisibility(this, viewIds, visibility);
     }
 
     public void setVisibilityController(int controllerId, List<Integer> controlledIds, boolean showWhenChecked) {
@@ -111,12 +100,12 @@ public class MaterialPreferenceScreen extends ScrollView {
 
     public void setUserInputModule(UserInputModule userInputModule) {
         this.userInputModule = userInputModule;
-        setUserInputModuleRecursively(container, userInputModule);
+        setUserInputModuleRecursively(this, userInputModule);
     }
 
     public void setStorageModule(StorageModule storageModule) {
         this.storageModule = storageModule;
-        setStorageModuleRecursively(container, storageModule);
+        setStorageModuleRecursively(this, storageModule);
     }
 
     private void setUserInputModuleRecursively(ViewGroup container, UserInputModule module) {
@@ -140,41 +129,4 @@ public class MaterialPreferenceScreen extends ScrollView {
             }
         }
     }
-
-    @Override
-    public void addView(View child) {
-        if (container != null) {
-            container.addView(child);
-        } else {
-            super.addView(child);
-        }
-    }
-
-    @Override
-    public void addView(View child, int index) {
-        if (container != null) {
-            container.addView(child, index);
-        } else {
-            super.addView(child, index);
-        }
-    }
-
-    @Override
-    public void addView(View child, ViewGroup.LayoutParams params) {
-        if (container != null) {
-            container.addView(child, params);
-        } else {
-            super.addView(child, params);
-        }
-    }
-
-    @Override
-    public void addView(View child, int index, ViewGroup.LayoutParams params) {
-        if (container != null) {
-            container.addView(child, index, params);
-        } else {
-            super.addView(child, index, params);
-        }
-    }
-
 }

--- a/lovelyinput/build.gradle
+++ b/lovelyinput/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'com.novoda.bintray-release'
 
 android {
     compileSdkVersion rootProject.compileSdkVersion
-    buildToolsVersion rootProject.buildToolsVersion
 
     defaultConfig {
         minSdkVersion 14

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion rootProject.compileSdkVersion
-    buildToolsVersion rootProject.buildToolsVersion
 
     defaultConfig {
         applicationId "com.yarolegovich.materialprefsample"

--- a/sample/src/main/res/layout/activity_config.xml
+++ b/sample/src/main/res/layout/activity_config.xml
@@ -1,11 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.yarolegovich.mp.MaterialPreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+            xmlns:app="http://schemas.android.com/apk/res-auto"
+            xmlns:tools="http://schemas.android.com/tools"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:fillViewport="true"
+            tools:context="com.yarolegovich.mp.MainActivity">
+
+<com.yarolegovich.mp.MaterialPreferenceScreen
     android:id="@+id/preference_screen"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    tools:context="com.yarolegovich.mp.MainActivity">
+    android:layout_height="wrap_content">
 
     <include layout="@layout/toolbar" />
 
@@ -98,4 +103,5 @@
 
     </com.yarolegovich.mp.MaterialPreferenceCategory>
 
-</com.yarolegovich.mp.MaterialPreferenceScreen>
+    </com.yarolegovich.mp.MaterialPreferenceScreen>
+</ScrollView>

--- a/sample/src/main/res/layout/activity_form.xml
+++ b/sample/src/main/res/layout/activity_form.xml
@@ -6,6 +6,9 @@
     android:layout_height="match_parent"
     tools:context=".FillTheFormActivity">
 
+    <ScrollView android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:fillViewport="true">
     <com.yarolegovich.mp.MaterialPreferenceScreen
         android:id="@+id/preference_screen"
         android:layout_width="match_parent"
@@ -58,6 +61,7 @@
         </com.yarolegovich.mp.MaterialPreferenceCategory>
 
     </com.yarolegovich.mp.MaterialPreferenceScreen>
+    </ScrollView>
 
     <android.support.design.widget.FloatingActionButton
         android:id="@+id/fab"

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -1,11 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.yarolegovich.mp.MaterialPreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+            xmlns:app="http://schemas.android.com/apk/res-auto"
+            xmlns:tools="http://schemas.android.com/tools"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:fillViewport="true"
+            tools:context="com.yarolegovich.mp.MainActivity">
+
+<com.yarolegovich.mp.MaterialPreferenceScreen
     android:id="@+id/preference_screen"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    tools:context="com.yarolegovich.mp.MainActivity">
+    android:layout_height="wrap_content">
 
     <FrameLayout
         android:layout_width="match_parent"
@@ -46,3 +51,4 @@
     </com.yarolegovich.mp.MaterialPreferenceCategory>
 
 </com.yarolegovich.mp.MaterialPreferenceScreen>
+</ScrollView>


### PR DESCRIPTION
By changing MaterialPreferenceScreen to LinearLayout, this would allow the view to be added into more complex scrollable context like NestedScrollView.

I've been using this in my project and have it placed inside a Android CoordinatorLayout.
